### PR TITLE
fix: adds git pull to update-image workflow

### DIFF
--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -40,6 +40,7 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Actions Bot"
+        git pull
         git add -A
         git commit -m "$SUBJECT" -m "$BODY"
         git push


### PR DESCRIPTION
Adds git pull to the update-image workflow.

If something else in the repository has been updated in the repository, this will incorporate that change before committing this one. 