### PR TITLE
adding github_token secret

### DIFF
--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -21,7 +21,8 @@ on:
         type: string
     secrets:
       GH_PACKAGE_READ_TOKEN:
-        required: true
+        required: false
+        default: ""
 
 jobs:
   build_production:
@@ -68,6 +69,7 @@ jobs:
         file: ${{ inputs.dockerfile }}
         secrets: |
           "gh_package_read_token=${{ secrets.GH_PACKAGE_READ_TOKEN }}"
+          "github_token=${{ secrets.GITHUB_TOKEN }}"
         push: true
         tags: | 
            ghcr.io/mlibrary/${{ inputs.image_name }}:latest

--- a/.github/workflows/build-unstable.yml
+++ b/.github/workflows/build-unstable.yml
@@ -21,7 +21,8 @@ on:
         type: string
     secrets:
       GH_PACKAGE_READ_TOKEN:
-        required: true
+        required: false
+        default: ""
     outputs:
       sha:
         description: "github commit hash that corressponds to the tag"
@@ -89,6 +90,7 @@ jobs:
         file: ${{ inputs.dockerfile }}
         secrets: |
           "gh_package_read_token=${{ secrets.GH_PACKAGE_READ_TOKEN }}"
+          "github_token=${{ secrets.GITHUB_TOKEN }}"
         push: true
         tags: | 
            ghcr.io/mlibrary/${{ inputs.image_name }}-unstable:latest


### PR DESCRIPTION
In the change to Github Enterprise the `GH_PACKAGE_READ_TOKEN` organization secret stopped working. This prompted an investigation which revealed that the provided `GITHUB_TOKEN` would work for most if not all of the purposes `GH_PACKAGE_READ_TOKEN` had been used. It had mostly been used to enable the installation of gems in the [Github RubyGems registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry#installing-a-package)

This PR makes the `GH_PACKAGE_READ_TOKEN` optional, and adds the `GITHUB_TOKEN` as a secret provided to build step. 

Dockerfiles that have used `gh_package_read_token` will need to be updated to use `github_token`. 