### PR TITLE
fix: removing the required false from the secrets

### DIFF
--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -21,8 +21,7 @@ on:
         type: string
     secrets:
       GH_PACKAGE_READ_TOKEN:
-        required: false
-        default: ""
+        required: true
 
 jobs:
   build_production:

--- a/.github/workflows/build-unstable.yml
+++ b/.github/workflows/build-unstable.yml
@@ -21,8 +21,7 @@ on:
         type: string
     secrets:
       GH_PACKAGE_READ_TOKEN:
-        required: false
-        default: ""
+        required: true
     outputs:
       sha:
         description: "github commit hash that corressponds to the tag"


### PR DESCRIPTION
Turns out default isn't an option for secrets in reusable workflows.