### PR TITLE
fix: add multiline payload to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,9 +67,10 @@ jobs:
         event-type: update-image
         token: ${{ steps.generate_token.outputs.token }}
         repository: ${{ env.CONFIG_REPO_FULL_NAME }}
-        client-payload: '{
-          "subject": "Update ${{ inputs.file }}",
-          "body": "Originating repository is ${{ github.repository }}\nRun ID is ${{ github.run_id }}\nUser is ${{ github.actor }}",
-          "image": "${{ inputs.image }}",
-          "file": "${{ inputs.file }}"
-        }'
+        client-payload: |-
+          {
+              "subject": "Update ${{ inputs.file }}",
+              "body": "Originating repository is ${{ github.repository }}\nRun ID is ${{ github.run_id }}\nUser is ${{ github.actor }}",
+              "image": "${{ inputs.image }}",
+              "file": "${{ inputs.file }}"
+          }


### PR DESCRIPTION
Vscode was complaining about the deploy.yml action. This PR changes the payload output to be a multiline JSON object instead of a JSON string