### PR TITLE
update-image retries pushing image

### DIFF
--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -33,14 +33,22 @@ jobs:
       run: echo -n $IMAGE > $FILE
     - name: cat the files
       run: cat ${{ inputs.file }}
-    - name: Commit and push files new file
+    - name: Commit the files
       env:
         SUBJECT: ${{ inputs.subject }}
         BODY: ${{ inputs.body }}
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Actions Bot"
-        git pull
         git add -A
         git commit -m "$SUBJECT" -m "$BODY"
-        git push
+    - name: pull and push the files
+      uses: nick-fields/retry@v3
+      with:
+        timeout_seconds: 30 
+        retry_wait_seconds: 30 
+        retry_on: error
+        max_attempts: 5
+        command: |
+          git pull --rebase
+          git push


### PR DESCRIPTION
When the same application image needs to be written to multiple files in a repository, the update-image action often doesn't have time to pull the latest version of the repository before trying to push. This means that one of the update-image workflow runs would fail.

This PR retries pulling the latest version of the repository and pushing the image. It uses the [retry-step](https://github.com/marketplace/actions/retry-step) action to do this. It retries up to 5 times. 