### PR TITLE
Use commit shas for all gha dependencies

### DIFF
--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -1,9 +1,8 @@
 name: Build production image
-
 on:
-  workflow_call: 
+  workflow_call:
     inputs:
-      docker_context: 
+      docker_context:
         type: string
         default: "."
         required: false
@@ -15,61 +14,60 @@ on:
         type: string
         required: true
         description: The base name of the image.
-      tag: 
+      tag:
         description: tag
         required: true
         type: string
     secrets:
       GH_PACKAGE_READ_TOKEN:
         required: true
-
 jobs:
   build_production:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    - name: Check that the tag exists in repo
-      id: tag_check
-      run: |
-        if git rev-parse 'refs/tags/${{ inputs.tag }}' &> /dev/null; then
-          echo 'tag=${{ inputs.tag }}' >> $GITHUB_OUTPUT
-        else
-          echo "Couldn't figure out tag from input: ${{ inputs.tag }}"
-          echo "Aborting deployment."
-          false
-        fi
-    - name: Log into Github Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Check that the tag exists in container registry
-      id: image_check
-      run: |
-        if docker manifest inspect ghcr.io/mlibrary/${{ inputs.image_name }}:${{ steps.tag_check.outputs.tag }} > /dev/null; then
-          echo 'image_exists=true' >> $GITHUB_OUTPUT
-          echo "image exists!"
-        else
-          echo "image doesn't exist; Starting to Build and push image"
-        fi
-    - name: Checkout Correct repository
-      if: ${{ steps.image_check.outputs.image_exists != 'true' }}
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ steps.tag_check.outputs.tag }}
-    - name: Build and Push
-      if: ${{ steps.image_check.outputs.image_exists != 'true' }}
-      uses: docker/build-push-action@v6
-      with:
-        context: ${{ inputs.docker_context }}
-        file: ${{ inputs.dockerfile }}
-        secrets: |
-          "gh_package_read_token=${{ secrets.GH_PACKAGE_READ_TOKEN }}"
-          "github_token=${{ secrets.GITHUB_TOKEN }}"
-        push: true
-        tags: | 
-           ghcr.io/mlibrary/${{ inputs.image_name }}:latest
-           ghcr.io/mlibrary/${{ inputs.image_name }}:${{ steps.tag_check.outputs.tag }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Check that the tag exists in repo
+        id: tag_check
+        run: |
+          if git rev-parse 'refs/tags/${{ inputs.tag }}' &> /dev/null; then
+            echo 'tag=${{ inputs.tag }}' >> $GITHUB_OUTPUT
+          else
+            echo "Couldn't figure out tag from input: ${{ inputs.tag }}"
+            echo "Aborting deployment."
+            false
+          fi
+      - name: Log into Github Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check that the tag exists in container registry
+        id: image_check
+        run: |
+          if docker manifest inspect ghcr.io/mlibrary/${{ inputs.image_name }}:${{ steps.tag_check.outputs.tag }} > /dev/null; then
+            echo 'image_exists=true' >> $GITHUB_OUTPUT
+            echo "image exists!"
+          else
+            echo "image doesn't exist; Starting to Build and push image"
+          fi
+      - name: Checkout Correct repository
+        if: ${{ steps.image_check.outputs.image_exists != 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.tag_check.outputs.tag }}
+      - name: Build and Push
+        if: ${{ steps.image_check.outputs.image_exists != 'true' }}
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: ${{ inputs.docker_context }}
+          file: ${{ inputs.dockerfile }}
+          secrets: |
+            "gh_package_read_token=${{ secrets.GH_PACKAGE_READ_TOKEN }}"
+            "github_token=${{ secrets.GITHUB_TOKEN }}"
+          push: true
+          tags: |
+            ghcr.io/mlibrary/${{ inputs.image_name }}:latest
+            ghcr.io/mlibrary/${{ inputs.image_name }}:${{ steps.tag_check.outputs.tag }}

--- a/.github/workflows/build-unstable.yml
+++ b/.github/workflows/build-unstable.yml
@@ -1,9 +1,8 @@
 name: Build unstable image
-
 on:
-  workflow_call: 
+  workflow_call:
     inputs:
-      docker_context: 
+      docker_context:
         type: string
         default: "."
         required: false
@@ -15,7 +14,7 @@ on:
         type: string
         required: true
         description: The base name of the image.
-      tag: 
+      tag:
         description: tag or commit sha
         required: false
         type: string
@@ -29,7 +28,6 @@ on:
       image:
         description: "full image address"
         value: ${{ jobs.build_unstable.outputs.image }}
-
 jobs:
   build_unstable:
     runs-on: ubuntu-latest
@@ -37,60 +35,60 @@ jobs:
       sha: ${{ steps.tag_check.outputs.tag }}
       image: ${{ steps.image_check.outputs.image }}
     steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    - name: Check that the tag exists in repo
-      env: 
-        TAG: ${{ inputs.tag }}
-      id: tag_check
-      run: |
-        if [ -z $TAG ]; then
-          echo "tag=`git rev-parse HEAD`" >> $GITHUB_OUTPUT
-        elif git rev-parse "refs/tags/$TAG" &> /dev/null; then
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-        elif git rev-parse "$TAG" &> /dev/null; then
-          SHA=`git rev-parse "$TAG"`
-          echo "$TAG corresponds to $SHA"
-          echo "tag=$SHA" >> $GITHUB_OUTPUT
-        else
-          echo "Couldn't figure out tag from input: $TAG"
-          echo "Aborting deployment."
-          false
-        fi
-    - name: Log into Github Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Check that the tag exists in container registry
-      id: image_check
-      env:
-        IMAGE: ghcr.io/mlibrary/${{ inputs.image_name }}-unstable:${{ steps.tag_check.outputs.tag }}
-      run: |
-        echo "image=$IMAGE" >> $GITHUB_OUTPUT
-        if docker manifest inspect $IMAGE > /dev/null; then
-          echo "image_exists=true" >> $GITHUB_OUTPUT
-          echo "image exists!"
-        else
-          echo "image doesn't exist; Starting to Build and push image"
-        fi
-    - name: Checkout Correct repository
-      if: ${{ steps.image_check.outputs.image_exists != 'true' }}
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ steps.tag_check.outputs.tag }}
-    - name: Build and Push
-      if: ${{ steps.image_check.outputs.image_exists != 'true' }}
-      uses: docker/build-push-action@v6
-      with:
-        context: ${{ inputs.docker_context }}
-        file: ${{ inputs.dockerfile }}
-        secrets: |
-          "gh_package_read_token=${{ secrets.GH_PACKAGE_READ_TOKEN }}"
-          "github_token=${{ secrets.GITHUB_TOKEN }}"
-        push: true
-        tags: | 
-           ghcr.io/mlibrary/${{ inputs.image_name }}-unstable:latest
-           ${{ steps.image_check.outputs.image }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Check that the tag exists in repo
+        env:
+          TAG: ${{ inputs.tag }}
+        id: tag_check
+        run: |
+          if [ -z $TAG ]; then
+            echo "tag=`git rev-parse HEAD`" >> $GITHUB_OUTPUT
+          elif git rev-parse "refs/tags/$TAG" &> /dev/null; then
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+          elif git rev-parse "$TAG" &> /dev/null; then
+            SHA=`git rev-parse "$TAG"`
+            echo "$TAG corresponds to $SHA"
+            echo "tag=$SHA" >> $GITHUB_OUTPUT
+          else
+            echo "Couldn't figure out tag from input: $TAG"
+            echo "Aborting deployment."
+            false
+          fi
+      - name: Log into Github Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check that the tag exists in container registry
+        id: image_check
+        env:
+          IMAGE: ghcr.io/mlibrary/${{ inputs.image_name }}-unstable:${{ steps.tag_check.outputs.tag }}
+        run: |
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+          if docker manifest inspect $IMAGE > /dev/null; then
+            echo "image_exists=true" >> $GITHUB_OUTPUT
+            echo "image exists!"
+          else
+            echo "image doesn't exist; Starting to Build and push image"
+          fi
+      - name: Checkout Correct repository
+        if: ${{ steps.image_check.outputs.image_exists != 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.tag_check.outputs.tag }}
+      - name: Build and Push
+        if: ${{ steps.image_check.outputs.image_exists != 'true' }}
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: ${{ inputs.docker_context }}
+          file: ${{ inputs.dockerfile }}
+          secrets: |
+            "gh_package_read_token=${{ secrets.GH_PACKAGE_READ_TOKEN }}"
+            "github_token=${{ secrets.GITHUB_TOKEN }}"
+          push: true
+          tags: |
+            ghcr.io/mlibrary/${{ inputs.image_name }}-unstable:latest
+            ${{ steps.image_check.outputs.image }}

--- a/.github/workflows/release-workflows.yml
+++ b/.github/workflows/release-workflows.yml
@@ -2,20 +2,17 @@ on:
   push:
     branches:
       - main
-
-permissions: 
+permissions:
   contents: write
   pull-requests: write
-
 name: release-please
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: tag major and minor versions
         if: ${{ steps.release.outputs.release_created }}
         run: |

--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -1,7 +1,6 @@
 name: Update image file in kube repository
-
 on:
-  workflow_call: 
+  workflow_call:
     inputs:
       subject:
         type: string
@@ -9,46 +8,45 @@ on:
       body:
         type: string
         required: true
-      image: 
+      image:
         type: string
         required: true
       file:
         type: string
         required: true
-
 jobs:
   update-image:
     runs-on: ubuntu-latest
     steps:
-    - name: Clone latest repository
-      uses: actions/checkout@v6
-    - name: dump github event
-      env:
-        EVENT: ${{ toJson(github.event) }}
-      run: echo "$EVENT"
-    - name: update the config
-      env: 
-        FILE: ${{ inputs.file }}
-        IMAGE: ${{ inputs.image }}
-      run: echo -n $IMAGE > $FILE
-    - name: cat the files
-      run: cat ${{ inputs.file }}
-    - name: Commit the files
-      env:
-        SUBJECT: ${{ inputs.subject }}
-        BODY: ${{ inputs.body }}
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Actions Bot"
-        git add -A
-        git commit -m "$SUBJECT" -m "$BODY"
-    - name: pull and push the files
-      uses: nick-fields/retry@v3
-      with:
-        timeout_seconds: 30 
-        retry_wait_seconds: 30 
-        retry_on: error
-        max_attempts: 5
-        command: |
-          git pull --rebase
-          git push
+      - name: Clone latest repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: dump github event
+        env:
+          EVENT: ${{ toJson(github.event) }}
+        run: echo "$EVENT"
+      - name: update the config
+        env:
+          FILE: ${{ inputs.file }}
+          IMAGE: ${{ inputs.image }}
+        run: echo -n $IMAGE > $FILE
+      - name: cat the files
+        run: cat ${{ inputs.file }}
+      - name: Commit the files
+        env:
+          SUBJECT: ${{ inputs.subject }}
+          BODY: ${{ inputs.body }}
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Actions Bot"
+          git add -A
+          git commit -m "$SUBJECT" -m "$BODY"
+      - name: pull and push the files
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
+        with:
+          timeout_seconds: 30
+          retry_wait_seconds: 30
+          retry_on: error
+          max_attempts: 5
+          command: |
+            git pull --rebase
+            git push


### PR DESCRIPTION
Per the latest Library IT Github policy, all Github Actions workflows need to depend on the commit sha of the dependent workflow. 

This PR adds the commit shas and commented version number for all of the dependencies. 