### PR TITLE
deploy uses commit shas; update github app token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,6 @@
 name: Deploy
-
 on:
-  workflow_call: 
+  workflow_call:
     inputs:
       environment:
         type: string
@@ -14,7 +13,7 @@ on:
       file:
         type: string
         required: true
-        description: path to file in repository to update with the image 
+        description: path to file in repository to update with the image
       CONFIG_REPO_RW_APP_ID:
         type: string
         required: false
@@ -27,50 +26,33 @@ on:
     secrets:
       CONFIG_REPO_RW_KEY:
         required: true
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    - name: Set environment variables
-      run: |
-        if [ -z "${{ inputs.CONFIG_REPO_RW_APP_ID }}" ] 
-        then
-          echo "CONFIG_REPO_RW_APP_ID=${{ vars.CONFIG_REPO_RW_APP_ID }}" >> $GITHUB_ENV
-          echo "setting CONFIG_REPO_RW_APP_ID to ${{ vars.CONFIG_REPO_RW_APP_ID }} from vars"
-        else  
-          echo "CONFIG_REPO_RW_APP_ID=${{ inputs.CONFIG_REPO_RW_APP_ID }}" >> $GITHUB_ENV
-          echo "setting CONFIG_REPO_RW_APP_ID to ${{ inputs.CONFIG_REPO_RW_APP_ID }} from inputs"
-        fi
-        if [ -z "${{ inputs.CONFIG_REPO_FULL_NAME }}" ] 
-        then
-          echo "CONFIG_REPO_FULL_NAME=${{ vars.CONFIG_REPO_FULL_NAME }}" >> $GITHUB_ENV
-          echo "setting CONFIG_REPO_FULL_NAME to ${{ vars.CONFIG_REPO_FULL_NAME }} from vars"
-        else  
-          echo "CONFIG_REPO_FULL_NAME=${{ inputs.CONFIG_REPO_FULL_NAME }}" >> $GITHUB_ENV
-          echo "setting CONFIG_REPO_FULL_NAME to ${{ inputs.CONFIG_REPO_FULL_NAME }} from inputs"
-        fi
-    - name: Generate app token
-      id: generate_token
-      uses: actions/create-github-app-token@v2
-      with:
-        app-id: ${{ env.CONFIG_REPO_RW_APP_ID }}
-        private-key: ${{ secrets.CONFIG_REPO_RW_KEY }}
-        owner: ${{ github.repository_owner }}
-    - name: Send the message
-      uses: peter-evans/repository-dispatch@v4
-      with:
-        event-type: update-image
-        token: ${{ steps.generate_token.outputs.token }}
-        repository: ${{ env.CONFIG_REPO_FULL_NAME }}
-        client-payload: |-
-          {
-              "subject": "Update ${{ inputs.file }}",
-              "body": "Originating repository is ${{ github.repository }}\nRun ID is ${{ github.run_id }}\nUser is ${{ github.actor }}",
-              "image": "${{ inputs.image }}",
-              "file": "${{ inputs.file }}"
-          }
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Set environment variables
+        run: "if [ -z \"${{ inputs.CONFIG_REPO_RW_APP_ID }}\" ] \nthen\n  echo \"CONFIG_REPO_RW_APP_ID=${{ vars.CONFIG_REPO_RW_APP_ID }}\" >> $GITHUB_ENV\n  echo \"setting CONFIG_REPO_RW_APP_ID to ${{ vars.CONFIG_REPO_RW_APP_ID }} from vars\"\nelse  \n  echo \"CONFIG_REPO_RW_APP_ID=${{ inputs.CONFIG_REPO_RW_APP_ID }}\" >> $GITHUB_ENV\n  echo \"setting CONFIG_REPO_RW_APP_ID to ${{ inputs.CONFIG_REPO_RW_APP_ID }} from inputs\"\nfi\nif [ -z \"${{ inputs.CONFIG_REPO_FULL_NAME }}\" ] \nthen\n  echo \"CONFIG_REPO_FULL_NAME=${{ vars.CONFIG_REPO_FULL_NAME }}\" >> $GITHUB_ENV\n  echo \"setting CONFIG_REPO_FULL_NAME to ${{ vars.CONFIG_REPO_FULL_NAME }} from vars\"\nelse  \n  echo \"CONFIG_REPO_FULL_NAME=${{ inputs.CONFIG_REPO_FULL_NAME }}\" >> $GITHUB_ENV\n  echo \"setting CONFIG_REPO_FULL_NAME to ${{ inputs.CONFIG_REPO_FULL_NAME }} from inputs\"\nfi\n"
+      - name: Generate app token
+        id: generate_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ env.CONFIG_REPO_RW_APP_ID }}
+          private-key: ${{ secrets.CONFIG_REPO_RW_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Send the message
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 #v4.0.1
+        with:
+          event-type: update-image
+          token: ${{ steps.generate_token.outputs.token }}
+          repository: ${{ env.CONFIG_REPO_FULL_NAME }}
+          client-payload: |-
+            {
+                "subject": "Update ${{ inputs.file }}",
+                "body": "Originating repository is ${{ github.repository }}\nRun ID is ${{ github.run_id }}\nUser is ${{ github.actor }}",
+                "image": "${{ inputs.image }}",
+                "file": "${{ inputs.file }}"
+            }


### PR DESCRIPTION
The deploy.yml workflow should also use commit shas for the dependencies now it does.

create-github-app-token was updated to to 3.0.0 as well.